### PR TITLE
refactor: improve caching in gas sources

### DIFF
--- a/test/integration/services/metadata/metadata-sources.spec.ts
+++ b/test/integration/services/metadata/metadata-sources.spec.ts
@@ -36,7 +36,7 @@ describe('Metadata Sources', () => {
   metadataSourceTest({
     title: 'RPC Source',
     source: RPC_METADATA_SOURCE,
-    fields: [{ fields: ['decimals', 'symbol'], on: 'all chains' }],
+    fields: [{ fields: ['decimals', 'symbol', 'name'], on: 'all chains' }],
   });
   metadataSourceTest({
     title: 'Defi Llama Source',
@@ -46,7 +46,10 @@ describe('Metadata Sources', () => {
   metadataSourceTest({
     title: 'Fallback Source',
     source: FALLBACK_METADATA_SOURCE,
-    fields: [{ fields: ['decimals', 'symbol'], on: 'all chains' }],
+    fields: [
+      { fields: ['decimals', 'symbol'], on: 'all chains' },
+      { fields: ['name'], on: chainsForSource(RPC_METADATA_SOURCE) },
+    ],
   });
   metadataSourceTest({
     title: 'Cached Source',
@@ -73,7 +76,7 @@ describe('Metadata Sources', () => {
             const totalAmountExpected = fieldsThatApply.reduce((accum, { fields }) => fields.length + accum, 0);
             expect(Object.keys(supportedProperties[chainId])).to.have.lengthOf(totalAmountExpected);
             for (const { fields: fieldsExist } of fieldsThatApply) {
-              expect(supportedProperties[chainId]).to.have.keys(fieldsExist);
+              expect(supportedProperties[chainId]).to.include.all.keys(fieldsExist);
             }
           }
         });
@@ -132,3 +135,6 @@ describe('Metadata Sources', () => {
     });
   }
 });
+function chainsForSource(source: IMetadataSource<object>) {
+  return Object.keys(source.supportedProperties()).map(Number);
+}

--- a/test/unit/services/gas/gas-calculator-builders/cached-gas-calculator-builder.spec.ts
+++ b/test/unit/services/gas/gas-calculator-builders/cached-gas-calculator-builder.spec.ts
@@ -1,5 +1,5 @@
 import chai, { expect } from 'chai';
-import { ChainId, FieldsRequirements, SupportRecord, TimeString } from '@types';
+import { ChainId, FieldRequirementOptions, FieldsRequirements, SupportRecord, TimeString } from '@types';
 import { then, when } from '@test-utils/bdd';
 import { EIP1159GasPrice, IQuickGasCostCalculator, IQuickGasCostCalculatorBuilder } from '@services/gas/types';
 import chaiAsPromised from 'chai-as-promised';
@@ -17,39 +17,51 @@ describe('Cached Gas Calculator Builder', () => {
   });
 
   cacheTest({
-    when: 'called for the second time with same requirements',
+    when: 'called for the second time with same required fields',
     calls: [
-      { chainId: CHAIN_ID, config: { timeout: '5s' } },
-      { chainId: CHAIN_ID, config: { timeout: '5s' } },
+      { chainId: CHAIN_ID, config: { timeout: '5s', fields: { requirements: { fast: 'required' } } } },
+      { chainId: CHAIN_ID, config: { timeout: '5s', fields: { requirements: { fast: 'required' } } } },
     ],
     expected: ['pass-through', 'cached'],
   });
 
   cacheTest({
-    when: 'called for the second time with same requirements but different timeout',
+    when: 'called for the second time with same required fields but different timeout',
     calls: [
-      { chainId: CHAIN_ID, config: { timeout: '5s' } },
-      { chainId: CHAIN_ID, config: { timeout: '15s' } },
+      { chainId: CHAIN_ID, config: { timeout: '5s', fields: { requirements: { fast: 'required' } } } },
+      { chainId: CHAIN_ID, config: { timeout: '15s', fields: { requirements: { fast: 'required' } } } },
     ],
     expected: ['pass-through', 'cached'],
   });
 
   cacheTest({
-    when: 'called for the second time with different requirements',
+    when: 'called for the second time with same required fields but different standard requirements',
     calls: [
-      { chainId: CHAIN_ID, config: { timeout: '5s' } },
+      { chainId: CHAIN_ID, config: { timeout: '5s', fields: { requirements: { fast: 'required', standard: 'best effort' } } } },
+      { chainId: CHAIN_ID, config: { timeout: '15s', fields: { requirements: { fast: 'required', standard: 'can ignore' } } } },
+    ],
+    expected: ['pass-through', 'cached'],
+  });
+
+  cacheTest({
+    when: 'called for the second time with different requirement parameters, but same underlying required fields',
+    calls: [
+      { chainId: CHAIN_ID, config: { timeout: '5s', fields: { requirements: { fast: 'required' } } } },
+      {
+        chainId: CHAIN_ID,
+        config: { timeout: '15s', fields: { requirements: { standard: 'best effort', instant: 'best effort' }, default: 'required' } },
+      },
+    ],
+    expected: ['pass-through', 'cached'],
+  });
+
+  cacheTest({
+    when: 'called for the second time with different required fields',
+    calls: [
+      { chainId: CHAIN_ID, config: { timeout: '5s', fields: { requirements: { standard: 'required' } } } },
       { chainId: CHAIN_ID, config: { timeout: '15s', fields: { requirements: { fast: 'required' } } } },
     ],
     expected: ['pass-through', 'pass-through'],
-  });
-
-  cacheTest({
-    when: 'called for the second time with different requirement parameters, but same underlying requirements',
-    calls: [
-      { chainId: CHAIN_ID, config: { timeout: '5s' } },
-      { chainId: CHAIN_ID, config: { timeout: '15s', fields: { requirements: { standard: 'required' } } } },
-    ],
-    expected: ['pass-through', 'cached'],
   });
 
   function cacheTest({ when: title, calls, expected }: { when: string; calls: CallParams[]; expected: ('pass-through' | 'cached')[] }) {
@@ -66,9 +78,15 @@ describe('Cached Gas Calculator Builder', () => {
         const expectedCalls = expected.filter((expected) => expected === 'pass-through').length;
         expect(wrapped.calls).to.have.lengthOf(expectedCalls);
         for (let i = 0; i < expectedCalls; i++) {
-          const requirements = calculateFieldRequirements(wrapped.supportedSpeeds()[CHAIN_ID], calls[i].config?.fields);
+          const fieldRequirements = calculateFieldRequirements(wrapped.supportedSpeeds()[CHAIN_ID], calls[i].config?.fields);
+          const requiredFields = Object.entries(fieldRequirements)
+            .filter(([, requirement]) => requirement === 'required')
+            .map(([field]) => field);
+          const requirements = Object.fromEntries(requiredFields.map((field) => [field, 'required'])) as Partial<
+            Record<keyof GasValues, FieldRequirementOptions>
+          >;
           expect(wrapped.calls[i].chainId).to.eql(calls[i].chainId);
-          expect(wrapped.calls[i].config).to.eql({ ...calls[i].config, fields: { requirements } });
+          expect(wrapped.calls[i].config).to.eql({ ...calls[i].config, fields: { requirements, default: 'best effort' } });
         }
       });
     });
@@ -76,12 +94,12 @@ describe('Cached Gas Calculator Builder', () => {
 });
 
 const RETURN_VALUE = { hello: true } as any;
-type GasValues = { standard: EIP1159GasPrice; fast?: EIP1159GasPrice; instant?: EIP1159GasPrice };
+type GasValues = { standard?: EIP1159GasPrice; fast?: EIP1159GasPrice; instant?: EIP1159GasPrice };
 class MockedGasCalculatorBuilder implements IQuickGasCostCalculatorBuilder<GasValues> {
   public calls: CallParams[] = [];
 
   supportedSpeeds() {
-    const support: SupportRecord<GasValues> = { standard: 'present', fast: 'optional', instant: 'optional' };
+    const support: SupportRecord<GasValues> = { standard: 'optional', fast: 'optional', instant: 'optional' };
     return { [CHAIN_ID]: support };
   }
   build<Requirements extends FieldsRequirements<GasValues>>(params: {

--- a/test/unit/services/metadata/metadata-sources/cached-metadata-source.spec.ts
+++ b/test/unit/services/metadata/metadata-sources/cached-metadata-source.spec.ts
@@ -38,7 +38,7 @@ describe('Cached Metadata Source', () => {
   });
 
   cacheTest({
-    when: 'called for the second time with same required fields but decimals requirements',
+    when: 'called for the second time with same required fields but different decimals requirements',
     calls: [
       { config: { timeout: '5s', fields: { requirements: { symbol: 'required', decimals: 'best effort' } } } },
       { config: { timeout: '15s', fields: { requirements: { symbol: 'required', decimals: 'can ignore' } } } },

--- a/test/unit/services/quotes/source-lists/default-source-list.spec.ts
+++ b/test/unit/services/quotes/source-lists/default-source-list.spec.ts
@@ -35,7 +35,7 @@ describe('Default Source List', () => {
     const sourceList = new DefaultSourceList({
       providerSource: PROVIDER_SOURCE,
       fetchService: FETCH_SERVICE,
-      metadataService: METADATA_SERVICE,
+      metadataService: METADATA_SERVICE as any,
       priceService: PRICE_SERVICE,
       gasService: FAILING_GAS_SERVICE,
       config: undefined,
@@ -59,7 +59,7 @@ describe('Default Source List', () => {
     const sourceList = new DefaultSourceList({
       providerSource: PROVIDER_SOURCE,
       fetchService: FETCH_SERVICE,
-      metadataService: METADATA_SERVICE,
+      metadataService: METADATA_SERVICE as any,
       priceService: PRICE_SERVICE,
       gasService: FAILING_GAS_SERVICE,
       config: undefined,


### PR DESCRIPTION
We are now using the same approach for caching as in the metadata cached source. The idea is to make the required fields part of the cache key, and then set the default requirements as "best effort"