### PR TITLE
refactor: normalize price service calls

### DIFF
--- a/src/services/prices/index.ts
+++ b/src/services/prices/index.ts
@@ -1,1 +1,1 @@
-export { IPriceService, IPriceSource, TokenPrice, HistoricalPriceResult } from './types';
+export { IPriceService, IPriceSource, TokenPrice, PriceResult } from './types';

--- a/src/services/prices/price-service.ts
+++ b/src/services/prices/price-service.ts
@@ -1,6 +1,6 @@
 import { timeoutPromise } from '@shared/timeouts';
 import { ChainId, TimeString, Timestamp, TokenAddress } from '@types';
-import { IPriceService, IPriceSource, TokenPrice } from './types';
+import { IPriceService, IPriceSource, PriceResult } from './types';
 
 export class PriceService implements IPriceService {
   constructor(private readonly priceSource: IPriceSource) {}
@@ -23,7 +23,7 @@ export class PriceService implements IPriceService {
     chainId: ChainId;
     addresses: TokenAddress[];
     config?: { timeout?: TimeString };
-  }): Promise<Record<TokenAddress, TokenPrice>> {
+  }): Promise<Record<TokenAddress, PriceResult>> {
     const byChainId = { [chainId]: addresses };
     const result = await this.getCurrentPrices({ addresses: byChainId, config });
     return result[chainId] ?? {};
@@ -35,7 +35,7 @@ export class PriceService implements IPriceService {
   }: {
     addresses: Record<ChainId, TokenAddress[]>;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, TokenPrice>>> {
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
     return timeoutPromise(this.priceSource.getCurrentPrices({ addresses, config }), config?.timeout, {
       description: 'Timeouted while fetching current prices',
     });

--- a/src/services/prices/price-sources/cached-price-source.ts
+++ b/src/services/prices/price-sources/cached-price-source.ts
@@ -1,14 +1,14 @@
 import { ChainId, TimeString, Timestamp, TokenAddress } from '@types';
 import { CacheConfig, ConcurrentLRUCache } from '@shared/concurrent-lru-cache';
-import { HistoricalPriceResult, IPriceSource, TokenPrice } from '../types';
+import { PriceResult, IPriceSource } from '../types';
 import { toTokenInChain, fromTokenInChain, TokenInChain } from '@shared/utils';
 
 type CacheContext = { timeout?: TimeString } | undefined;
 export class CachedPriceSource implements IPriceSource {
-  private readonly cache: ConcurrentLRUCache<CacheContext, TokenInChain, TokenPrice>;
+  private readonly cache: ConcurrentLRUCache<CacheContext, TokenInChain, PriceResult>;
 
   constructor(private readonly source: IPriceSource, config: CacheConfig) {
-    this.cache = new ConcurrentLRUCache<CacheContext, TokenInChain, TokenPrice>({
+    this.cache = new ConcurrentLRUCache<CacheContext, TokenInChain, PriceResult>({
       calculate: (context, tokensInChain) => this.fetchTokens(tokensInChain, context),
       config,
     });
@@ -24,7 +24,7 @@ export class CachedPriceSource implements IPriceSource {
   }: {
     addresses: Record<ChainId, TokenAddress[]>;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, TokenPrice>>> {
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
     const tokensInChain = addressesToTokensInChain(addresses);
     const tokens = await this.cache.getOrCalculate({ keys: tokensInChain, context: config, timeout: config?.timeout });
     return tokenInChainRecordToChainAndAddress(tokens);
@@ -40,12 +40,12 @@ export class CachedPriceSource implements IPriceSource {
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, HistoricalPriceResult>>> {
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
     // TODO: Support caching, but make it configurable
     return this.source.getHistoricalPrices({ addresses, timestamp, searchWidth, config });
   }
 
-  private async fetchTokens(tokensInChain: TokenInChain[], context?: CacheContext): Promise<Record<TokenInChain, TokenPrice>> {
+  private async fetchTokens(tokensInChain: TokenInChain[], context?: CacheContext): Promise<Record<TokenInChain, PriceResult>> {
     const addresses = tokensInChainToAddresses(tokensInChain);
     const tokens = await this.source.getCurrentPrices({ addresses, config: { timeout: context?.timeout } });
     return chainAndAddressRecordToTokenInChain(tokens);
@@ -69,8 +69,8 @@ function tokensInChainToAddresses(tokensInChain: TokenInChain[]): Record<ChainId
   return result;
 }
 
-function tokenInChainRecordToChainAndAddress(record: Record<TokenInChain, TokenPrice>): Record<ChainId, Record<TokenAddress, TokenPrice>> {
-  const result: Record<ChainId, Record<TokenAddress, TokenPrice>> = {};
+function tokenInChainRecordToChainAndAddress(record: Record<TokenInChain, PriceResult>): Record<ChainId, Record<TokenAddress, PriceResult>> {
+  const result: Record<ChainId, Record<TokenAddress, PriceResult>> = {};
   for (const [tokenInChain, token] of Object.entries(record)) {
     const { chainId, address } = fromTokenInChain(tokenInChain);
     if (!(chainId in result)) {
@@ -81,9 +81,9 @@ function tokenInChainRecordToChainAndAddress(record: Record<TokenInChain, TokenP
   return result;
 }
 
-function chainAndAddressRecordToTokenInChain(record: Record<ChainId, Record<TokenAddress, TokenPrice>>): Record<TokenInChain, TokenPrice> {
+function chainAndAddressRecordToTokenInChain(record: Record<ChainId, Record<TokenAddress, PriceResult>>): Record<TokenInChain, PriceResult> {
   const entries = Object.entries(record).flatMap(([chainId, record]) =>
-    Object.entries(record).map<[TokenInChain, TokenPrice]>(([address, token]) => [toTokenInChain(parseInt(chainId), address), token])
+    Object.entries(record).map<[TokenInChain, PriceResult]>(([address, token]) => [toTokenInChain(parseInt(chainId), address), token])
   );
   return Object.fromEntries(entries);
 }

--- a/src/services/prices/price-sources/coingecko-price-source.ts
+++ b/src/services/prices/price-sources/coingecko-price-source.ts
@@ -1,6 +1,6 @@
 import { ChainId, TimeString, Timestamp, TokenAddress } from '@types';
 import { IFetchService } from '@services/fetch/types';
-import { HistoricalPriceResult, IPriceSource, PricesQueriesSupport, TokenPrice } from '../types';
+import { PriceResult, IPriceSource, PricesQueriesSupport, TokenPrice } from '../types';
 import { Chains } from '@chains';
 import { reduceTimeout, timeoutPromise } from '@shared/timeouts';
 import { filterRejectedResults, isSameAddress } from '@shared/utils';
@@ -55,7 +55,7 @@ export class CoingeckoPriceSource implements IPriceSource {
   }: {
     addresses: Record<ChainId, TokenAddress[]>;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, TokenPrice>>> {
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
     const reducedTimeout = reduceTimeout(config?.timeout, '100');
     const promises = Object.entries(addresses).map(async ([chainId, addresses]) => [
       Number(chainId),
@@ -69,7 +69,7 @@ export class CoingeckoPriceSource implements IPriceSource {
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, HistoricalPriceResult>>> {
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
     // TODO: Add support
     throw new Error('Operation not supported');
   }
@@ -86,25 +86,29 @@ export class CoingeckoPriceSource implements IPriceSource {
     return Object.fromEntries(addresses.map((address) => [address, erc20LowerCased[address.toLowerCase()]]));
   }
 
-  private async fetchNativePrice(chainId: ChainId, timeout?: TimeString): Promise<TokenPrice> {
+  private async fetchNativePrice(chainId: ChainId, timeout?: TimeString): Promise<PriceResult> {
     const { nativeTokenKey } = COINGECKO_CHAIN_KEYS[chainId];
-    const url = `https://api.coingecko.com/api/v3/simple/price?ids=${nativeTokenKey}&vs_currencies=usd`;
+    const url = `https://api.coingecko.com/api/v3/simple/price?ids=${nativeTokenKey}&vs_currencies=usd&include_last_updated_at=true`;
     const response = await this.fetch.fetch(url, { timeout, headers: { Accept: 'application/json' } });
     const body = await response.json();
-    return body[nativeTokenKey].usd;
+    return { price: body[nativeTokenKey].usd, timestamp: body[nativeTokenKey].last_updated_at };
   }
 
-  private async fetchERC20Prices(chainId: ChainId, addresses: TokenAddress[], timeout?: TimeString): Promise<Record<TokenAddress, TokenPrice>> {
+  private async fetchERC20Prices(chainId: ChainId, addresses: TokenAddress[], timeout?: TimeString): Promise<Record<TokenAddress, PriceResult>> {
     if (addresses.length === 0) return {};
     const url =
       `https://api.coingecko.com/api/v3/simple/token_price/${COINGECKO_CHAIN_KEYS[chainId].chainKey}` +
       `?contract_addresses=${addresses.join(',')}` +
-      '&vs_currencies=usd';
+      '&vs_currencies=usd' +
+      '&include_last_updated_at=true';
     const response = await this.fetch.fetch(url, { timeout });
     const body: TokenPriceResponse = await response.json();
-    const entries = Object.entries(body).map(([token, { usd }]) => [token.toLowerCase(), usd]);
+    const entries = Object.entries(body).map(([token, { usd, last_updated_at }]) => [
+      token.toLowerCase(),
+      { price: usd, timestamp: last_updated_at },
+    ]);
     return Object.fromEntries(entries);
   }
 }
 
-type TokenPriceResponse = Record<TokenAddress, { usd: TokenPrice }>;
+type TokenPriceResponse = Record<TokenAddress, { usd: TokenPrice; last_updated_at: Timestamp }>;

--- a/src/services/prices/price-sources/defi-llama-price-source.ts
+++ b/src/services/prices/price-sources/defi-llama-price-source.ts
@@ -1,6 +1,6 @@
 import { ChainId, TimeString, Timestamp, TokenAddress } from '@types';
 import { IFetchService } from '@services/fetch/types';
-import { HistoricalPriceResult, IPriceSource, PricesQueriesSupport, TokenPrice } from '../types';
+import { PriceResult, IPriceSource, PricesQueriesSupport } from '../types';
 import { DefiLlamaClient } from '@shared/defi-llama';
 
 export class DefiLlamaPriceSource implements IPriceSource {
@@ -19,14 +19,14 @@ export class DefiLlamaPriceSource implements IPriceSource {
   async getCurrentPrices(params: {
     addresses: Record<ChainId, TokenAddress[]>;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, TokenPrice>>> {
-    const result: Record<ChainId, Record<TokenAddress, TokenPrice>> = {};
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
+    const result: Record<ChainId, Record<TokenAddress, PriceResult>> = {};
     const data = await this.defiLlama.getCurrentTokenData(params);
     for (const [chainIdString, tokens] of Object.entries(data)) {
       const chainId = Number(chainIdString);
       result[chainId] = {};
       for (const [address, token] of Object.entries(tokens)) {
-        result[chainId][address] = token.price;
+        result[chainId][address] = { price: token.price, timestamp: token.timestamp };
       }
     }
     return result;
@@ -37,8 +37,8 @@ export class DefiLlamaPriceSource implements IPriceSource {
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, HistoricalPriceResult>>> {
-    const result: Record<ChainId, Record<TokenAddress, HistoricalPriceResult>> = {};
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
+    const result: Record<ChainId, Record<TokenAddress, PriceResult>> = {};
     const data = await this.defiLlama.getHistoricalTokenData(params);
     for (const [chainIdString, tokens] of Object.entries(data)) {
       const chainId = Number(chainIdString);

--- a/src/services/prices/price-sources/fastest-price-source.ts
+++ b/src/services/prices/price-sources/fastest-price-source.ts
@@ -1,6 +1,6 @@
 import { reduceTimeout, timeoutPromise } from '@shared/timeouts';
 import { ChainId, TimeString, Timestamp, TokenAddress } from '@types';
-import { HistoricalPriceResult, IPriceSource, PricesQueriesSupport } from '../types';
+import { PriceResult, IPriceSource, PricesQueriesSupport } from '../types';
 import {
   filterRequestForSource,
   fillResponseWithNewResult,
@@ -44,7 +44,7 @@ export class FastestPriceSource implements IPriceSource {
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, HistoricalPriceResult>>> {
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
     return executeFastest(
       this.sources,
       addresses,

--- a/src/services/prices/price-sources/moralis-price-source.ts
+++ b/src/services/prices/price-sources/moralis-price-source.ts
@@ -1,10 +1,11 @@
 import { Address, ChainId, TimeString, Timestamp, TokenAddress } from '@types';
 import { Chains, getChainByKey } from '@chains';
-import { HistoricalPriceResult, IPriceSource, PricesQueriesSupport, TokenPrice } from '../types';
+import { PriceResult, IPriceSource, PricesQueriesSupport } from '../types';
 import { IFetchService } from '@services/fetch';
 import { isSameAddress, toTrimmedHex } from '@shared/utils';
 import { Addresses } from '@shared/constants';
 import { reduceTimeout } from '@shared/timeouts';
+import { nowInSeconds } from './utils';
 
 const SUPPORTED_CHAINS = [Chains.ETHEREUM, Chains.POLYGON, Chains.BNB_CHAIN, Chains.AVALANCHE, Chains.FANTOM, Chains.ARBITRUM, Chains.CRONOS];
 
@@ -23,8 +24,8 @@ export class MoralisPriceSource implements IPriceSource {
   }: {
     addresses: Record<ChainId, TokenAddress[]>;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, TokenPrice>>> {
-    const result: Record<ChainId, Record<TokenAddress, TokenPrice>> = Object.fromEntries(
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
+    const result: Record<ChainId, Record<TokenAddress, PriceResult>> = Object.fromEntries(
       Object.keys(addresses).map((chainId) => [Number(chainId), {}])
     );
     const reducedTimeout = reduceTimeout(config?.timeout, '100');
@@ -45,18 +46,18 @@ export class MoralisPriceSource implements IPriceSource {
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, HistoricalPriceResult>>> {
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
     return Promise.reject(new Error('Operation not supported'));
   }
 
-  private async fetchPrice(chainId: ChainId, address: Address, config?: { timeout?: TimeString }): Promise<TokenPrice | undefined> {
+  private async fetchPrice(chainId: ChainId, address: Address, config?: { timeout?: TimeString }): Promise<PriceResult | undefined> {
     const addressToFetch = isSameAddress(address, Addresses.NATIVE_TOKEN) ? getChainByKey(chainId)?.wToken : address;
     if (!addressToFetch) return undefined;
     const body = await this.fetch(
       `https://deep-index.moralis.io/api/v2/erc20/${addressToFetch.toLowerCase()}/price?chain=${chainIdToValidChain(chainId)}`,
       config?.timeout
     );
-    return body.usdPrice;
+    return { price: body.usdPrice, timestamp: nowInSeconds() };
   }
 
   private async fetch(url: string, timeout?: TimeString): Promise<any> {

--- a/src/services/prices/price-sources/prioritized-price-source.ts
+++ b/src/services/prices/price-sources/prioritized-price-source.ts
@@ -1,6 +1,6 @@
 import { reduceTimeout, timeoutPromise } from '@shared/timeouts';
 import { ChainId, TimeString, Timestamp, TokenAddress } from '@types';
-import { HistoricalPriceResult, IPriceSource, PricesQueriesSupport } from '../types';
+import { PriceResult, IPriceSource, PricesQueriesSupport } from '../types';
 import {
   doesResponseFulfillRequest,
   fillResponseWithNewResult,
@@ -44,7 +44,7 @@ export class PrioritizedPriceSource implements IPriceSource {
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, HistoricalPriceResult>>> {
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>> {
     return executePrioritized(
       this.sources,
       addresses,

--- a/src/services/prices/price-sources/utils.ts
+++ b/src/services/prices/price-sources/utils.ts
@@ -64,3 +64,7 @@ export function getSourcesThatSupportRequestOrFail(
   if (sourcesInChain.length === 0) throw new Error(`Current price sources can't support all the given chains`);
   return sourcesInChain;
 }
+
+export function nowInSeconds() {
+  return Math.floor(Date.now() / 1000);
+}

--- a/src/services/prices/types.ts
+++ b/src/services/prices/types.ts
@@ -9,24 +9,24 @@ export type IPriceService = {
     chainId: ChainId;
     addresses: TokenAddress[];
     config?: { timeout?: TimeString };
-  }): Promise<Record<TokenAddress, TokenPrice>>;
+  }): Promise<Record<TokenAddress, PriceResult>>;
   getCurrentPrices(_: {
     addresses: Record<ChainId, TokenAddress[]>;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, TokenPrice>>>;
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>>;
   getHistoricalPricesForChain(_: {
     chainId: ChainId;
     addresses: TokenAddress[];
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<TokenAddress, HistoricalPriceResult>>;
+  }): Promise<Record<TokenAddress, PriceResult>>;
   getHistoricalPrices(_: {
     addresses: Record<ChainId, TokenAddress[]>;
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, HistoricalPriceResult>>>;
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>>;
 };
 
 export type PricesQueriesSupport = {
@@ -34,18 +34,18 @@ export type PricesQueriesSupport = {
   getCurrentPrices: true;
 };
 
-export type HistoricalPriceResult = { price: TokenPrice; timestamp: Timestamp };
+export type PriceResult = { price: TokenPrice; timestamp: Timestamp };
 
 export type IPriceSource = {
   supportedQueries(): Record<ChainId, PricesQueriesSupport>;
   getCurrentPrices(_: {
     addresses: Record<ChainId, TokenAddress[]>;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, TokenPrice>>>;
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>>;
   getHistoricalPrices(_: {
     addresses: Record<ChainId, TokenAddress[]>;
     timestamp: Timestamp;
     searchWidth?: TimeString;
     config?: { timeout?: TimeString };
-  }): Promise<Record<ChainId, Record<TokenAddress, HistoricalPriceResult>>>;
+  }): Promise<Record<ChainId, Record<TokenAddress, PriceResult>>>;
 };

--- a/test/integration/services/prices/price-sources.spec.ts
+++ b/test/integration/services/prices/price-sources.spec.ts
@@ -70,7 +70,8 @@ describe('Token Price Sources', () => {
             config: { timeout: '10s' },
           }),
         validation: (price) => {
-          expect(typeof price).to.equal('number');
+          expect(typeof price.price).to.equal('number');
+          expect(typeof price.timestamp).to.equal('number');
         },
       });
       queryTest({

--- a/test/unit/services/prices/price-sources/aggregator-price-source.spec.ts
+++ b/test/unit/services/prices/price-sources/aggregator-price-source.spec.ts
@@ -3,7 +3,7 @@ import chaiAsPromised from 'chai-as-promised';
 import { given, then, when } from '@test-utils/bdd';
 import { ChainId, TokenAddress } from '@types';
 import { AggregatorPriceSource, PriceAggregationMethod } from '@services/prices/price-sources/aggregator-price-source';
-import { IPriceSource, TokenPrice } from '@services/prices';
+import { IPriceSource, PriceResult, TokenPrice } from '@services/prices';
 chai.use(chaiAsPromised);
 
 const TOKEN_A = '0x0000000000000000000000000000000000000001';
@@ -92,7 +92,7 @@ describe('Aggregator Price Source', () => {
     method: PriceAggregationMethod;
   }) {
     when(`aggregating by ${method}`, () => {
-      let result: Record<TokenAddress, TokenPrice>;
+      let result: Record<TokenAddress, PriceResult>;
       given(async () => {
         const sources = prices.map((price) => buildSource(price));
         const allTokens = [...new Set(prices.flatMap((prices) => Object.keys(prices)))];

--- a/test/unit/services/prices/price-sources/aggregator-price-source.spec.ts
+++ b/test/unit/services/prices/price-sources/aggregator-price-source.spec.ts
@@ -30,7 +30,7 @@ describe('Aggregator Price Source', () => {
 
   when('there is only one source that works', () => {
     then('that result is returned', async () => {
-      const prices = { [TOKEN_A]: 10 };
+      const prices = { [TOKEN_A]: { price: 10, timestamp: 20 } };
       const aggregator = new AggregatorPriceSource([buildSource(prices, 1), buildSourceThatFails(1)], 'median');
       const result = await aggregator.getCurrentPrices({ addresses: { [1]: [TOKEN_A] } });
       expect(result).to.deep.equal({ [1]: prices });
@@ -94,19 +94,19 @@ describe('Aggregator Price Source', () => {
     when(`aggregating by ${method}`, () => {
       let result: Record<TokenAddress, PriceResult>;
       given(async () => {
-        const sources = prices.map((price) => buildSource(price));
+        const sources = prices.map((price) => buildSource(addTimestamp(price)));
         const allTokens = [...new Set(prices.flatMap((prices) => Object.keys(prices)))];
         const aggSource = new AggregatorPriceSource(sources, method);
         result = await aggSource.getCurrentPrices({ addresses: { [1]: allTokens } }).then((result) => result[1]);
       });
 
       then('result is as expected', () => {
-        expect(result).to.deep.equal(expected);
+        expect(result).to.deep.equal(addTimestamp(expected));
       });
     });
   }
 
-  function buildSource(prices: Record<TokenAddress, TokenPrice>, chainId: ChainId = 1): IPriceSource {
+  function buildSource(prices: Record<TokenAddress, PriceResult>, chainId: ChainId = 1): IPriceSource {
     return {
       getHistoricalPrices: () => Promise.reject('Not supported'),
       supportedQueries: () => ({ [chainId]: { getHistoricalPrices: false, getCurrentPrices: true } }),
@@ -120,5 +120,9 @@ describe('Aggregator Price Source', () => {
       supportedQueries: () => Object.fromEntries(onChain.map((chainId) => [chainId, { getHistoricalPrices: false, getCurrentPrices: true }])),
       getCurrentPrices: () => Promise.reject(new Error('Something failed')),
     };
+  }
+
+  function addTimestamp(prices: Record<TokenAddress, TokenPrice>): Record<TokenAddress, PriceResult> {
+    return Object.fromEntries(Object.entries(prices).map(([token, price]) => [token, { price, timestamp: price }]));
   }
 });

--- a/test/unit/services/prices/price-sources/fastest-price-source.spec.ts
+++ b/test/unit/services/prices/price-sources/fastest-price-source.spec.ts
@@ -2,7 +2,7 @@ import chai, { expect } from 'chai';
 import { then, when } from '@test-utils/bdd';
 import { ChainId, TokenAddress } from '@types';
 import chaiAsPromised from 'chai-as-promised';
-import { IPriceSource, TokenPrice } from '@services/prices';
+import { IPriceSource, PriceResult, TokenPrice } from '@services/prices';
 import { FastestPriceSource } from '@services/prices/price-sources/fastest-price-source';
 chai.use(chaiAsPromised);
 
@@ -29,7 +29,7 @@ describe('Fastest Price Source', () => {
     then('resolves without waiting for first one', async () => {
       const { source: source1 } = source({ chains: [1] });
       const { source: source2, promise: source2Promise } = source({ chains: [1] });
-      const result = { [1]: { [TOKEN_A]: 20 } };
+      const result = { [1]: { [TOKEN_A]: { price: 20, timestamp: 20 } } };
 
       const promise = getPrices({ addresses: { [1]: [TOKEN_A] }, sources: [source1, source2] });
       await wait();
@@ -45,7 +45,7 @@ describe('Fastest Price Source', () => {
     then('resolves without waiting for second one', async () => {
       const { source: source1, promise: source1Promise } = source({ chains: [1] });
       const { source: source2 } = source({ chains: [1] });
-      const result1 = { [1]: { [TOKEN_A]: 10 } };
+      const result1 = { [1]: { [TOKEN_A]: { price: 10, timestamp: 10 } } };
 
       const promise = getPrices({ addresses: { [1]: [TOKEN_A] }, sources: [source1, source2] });
       await wait();
@@ -61,8 +61,8 @@ describe('Fastest Price Source', () => {
     then('the first one to resolve is returned', async () => {
       const { source: source1, promise: source1Promise } = source({ chains: [1] });
       const { source: source2, promise: source2Promise } = source({ chains: [1] });
-      const result1 = { [1]: { [TOKEN_A]: 10 } };
-      const result2 = { [1]: { [TOKEN_A]: 20 } };
+      const result1 = { [1]: { [TOKEN_A]: { price: 10, timestamp: 10 } } };
+      const result2 = { [1]: { [TOKEN_A]: { price: 20, timestamp: 20 } } };
 
       const promise = getPrices({ addresses: { [1]: [TOKEN_A] }, sources: [source1, source2] });
       await wait();
@@ -79,8 +79,8 @@ describe('Fastest Price Source', () => {
     then('waits for the second one', async () => {
       const { source: source1, promise: source1Promise } = source({ chains: [1] });
       const { source: source2, promise: source2Promise } = source({ chains: [1] });
-      const result1 = { [1]: { [TOKEN_A]: 10 } };
-      const result2 = { [1]: { [TOKEN_B]: 20 } };
+      const result1 = { [1]: { [TOKEN_A]: { price: 10, timestamp: 10 } } };
+      const result2 = { [1]: { [TOKEN_B]: { price: 20, timestamp: 20 } } };
 
       const promise = getPrices({ addresses: { [1]: [TOKEN_A, TOKEN_B] }, sources: [source1, source2] });
       await wait();
@@ -91,7 +91,7 @@ describe('Fastest Price Source', () => {
       source2Promise.resolve(result2);
       await wait();
       expect(promise.status).to.equal('resolved');
-      expect(await promise.result).to.deep.equal({ [1]: { [TOKEN_A]: 10, [TOKEN_B]: 20 } });
+      expect(await promise.result).to.deep.equal({ [1]: { [TOKEN_A]: { price: 10, timestamp: 10 }, [TOKEN_B]: { price: 20, timestamp: 20 } } });
     });
   });
 
@@ -99,8 +99,8 @@ describe('Fastest Price Source', () => {
     then('result it is returned anyways', async () => {
       const { source: source1, promise: source1Promise } = source({ chains: [1] });
       const { source: source2, promise: source2Promise } = source({ chains: [1] });
-      const result1 = { [1]: { [TOKEN_A]: 10 } };
-      const result2 = { [1]: { [TOKEN_A]: 20 } };
+      const result1 = { [1]: { [TOKEN_A]: { price: 10, timestamp: 10 } } };
+      const result2 = { [1]: { [TOKEN_A]: { price: 20, timestamp: 20 } } };
 
       const promise = getPrices({ addresses: { [1]: [TOKEN_A, TOKEN_B] }, sources: [source1, source2] });
       await wait();
@@ -119,7 +119,7 @@ describe('Fastest Price Source', () => {
     then('second one is returned', async () => {
       const { source: source1, promise: source1Promise } = source({ chains: [1] });
       const { source: source2, promise: source2Promise } = source({ chains: [1] });
-      const result = { [1]: { [TOKEN_A]: 20 } };
+      const result = { [1]: { [TOKEN_A]: { price: 20, timestamp: 20 } } };
 
       const promise = getPrices({ addresses: { [1]: [TOKEN_A] }, sources: [source1, source2] });
       await wait();
@@ -138,7 +138,7 @@ describe('Fastest Price Source', () => {
     then('second result is returned', async () => {
       const { source: source1 } = source({ chains: [2] });
       const { source: source2, promise: source2Promise } = source({ chains: [1] });
-      const result = { [1]: { [TOKEN_A]: 20 } };
+      const result = { [1]: { [TOKEN_A]: { price: 20, timestamp: 20 } } };
 
       const promise = getPrices({ addresses: { [1]: [TOKEN_A] }, sources: [source1, source2] });
       await wait();
@@ -154,8 +154,8 @@ describe('Fastest Price Source', () => {
     then('results are combined', async () => {
       const { source: source1, promise: source1Promise } = source({ chains: [1] });
       const { source: source2, promise: source2Promise } = source({ chains: [2] });
-      const result1 = { [1]: { [TOKEN_A]: 20 } };
-      const result2 = { [2]: { [TOKEN_B]: 10 } };
+      const result1 = { [1]: { [TOKEN_A]: { price: 20, timestamp: 20 } } };
+      const result2 = { [2]: { [TOKEN_B]: { price: 10, timestamp: 10 } } };
 
       const promise = getPrices({ addresses: { [1]: [TOKEN_A], [2]: [TOKEN_B] }, sources: [source1, source2] });
       await wait();
@@ -208,9 +208,9 @@ function promise<T>(): PromiseWithTriggers<T> {
 
 function source({ chains }: { chains: ChainId[] }): {
   source: IPriceSource;
-  promise: PromiseWithTriggers<Record<ChainId, Record<TokenAddress, TokenPrice>>>;
+  promise: PromiseWithTriggers<Record<ChainId, Record<TokenAddress, PriceResult>>>;
 } {
-  const sourcePromise = promise<Record<ChainId, Record<TokenAddress, TokenPrice>>>();
+  const sourcePromise = promise<Record<ChainId, Record<TokenAddress, PriceResult>>>();
   const source: IPriceSource = {
     getCurrentPrices: () => sourcePromise,
     getHistoricalPrices: () => Promise.reject('Not supported'),

--- a/test/unit/services/quotes/quote-service.spec.ts
+++ b/test/unit/services/quotes/quote-service.spec.ts
@@ -135,7 +135,8 @@ const PRICE_SERVICE: IPriceService = {
   supportedChains: () => [1],
   supportedQueries: () => ({ [1]: { getCurrentPrices: true, getHistoricalPrices: true } }),
   getCurrentPrices: () => Promise.reject(new Error('Should not be called')),
-  getCurrentPricesForChain: ({ addresses }) => Promise.resolve(Object.fromEntries(addresses.map((address, i) => [address, i * 10]))),
+  getCurrentPricesForChain: ({ addresses }) =>
+    Promise.resolve(Object.fromEntries(addresses.map((address, i) => [address, { price: i * 10, timestamp: 0 }]))),
   getHistoricalPrices: () => Promise.reject(new Error('Should not be called')),
   getHistoricalPricesForChain: () => Promise.reject(new Error('Should not be called')),
 };


### PR DESCRIPTION
We are now normalizing the Price Service's calls,  so that they return the same structure. Since most price sources provide a timestamp from when the price was calculated, it made sense to return it

If the price source doesn't return it, then we will simply return `"now"`