### PR TITLE
feat: add migrate to position mgmt service

### DIFF
--- a/src/services/dca/types.ts
+++ b/src/services/dca/types.ts
@@ -14,6 +14,7 @@ export type IDCAPositionManagementService = {
   buildReduceToBuyPositionTx(_: ReduceToBuyDCAPositionParams): Promise<BuiltTransaction>;
   buildWithdrawPositionTx(_: WithdrawDCAPositionParams): Promise<BuiltTransaction>;
   buildTerminatePositionTx(_: TerminateDCAPositionParams): Promise<BuiltTransaction>;
+  buildMigratePositionTx(_: MigrateDCAPositionParams): Promise<BuiltTransaction>;
 };
 
 export enum DCAPermission {
@@ -87,6 +88,19 @@ export type TerminateDCAPositionParams = {
   permissionPermit?: DCAPermissionPermit;
   dcaHub?: Address;
 };
+export type MigrateDCAPositionParams = {
+  chainId: ChainId;
+  sourceHub: Address;
+  targetHub: Address;
+  positionId: BigIntish;
+  permissionPermit?: DCAPermissionPermit;
+  migration: PositionMigration & { newFrom?: PositionToken; newTo?: PositionToken; swapConfig?: DCAActionSwapConfig };
+};
+
+type PositionMigration =
+  | { useFundsFrom: 'swapped' | 'unswapped'; sendUnusedFundsTo: Address }
+  | { useFundsFrom: 'both'; sendUnusedFundsTo?: undefined };
+
 export type DCAActionSwapConfig = { slippagePercentage?: number; txValidFor?: TimeString };
 export type DCAPermissionPermit = {
   permissions: DCAPermissionSet[];


### PR DESCRIPTION
We are now adding a new method to migrate positions between hubs. This migration can:
- Use `unswapped` funds, `swapped` funds or `both`
  - All unused funds will be sent to a specified recipient
- As part of the migration, the user can also specify new `from` and `to` tokens
  - If not specified, then we'll use the values from the origin position
  - We will automatically swap any used funds to new `from` if necessary