### PR TITLE
feat: fill history prices if necessary

### DIFF
--- a/src/sdk/builders/dca-builder.ts
+++ b/src/sdk/builders/dca-builder.ts
@@ -2,6 +2,7 @@ import { DCAService } from '@services/dca/dca-service';
 import { IFetchService } from '@services/fetch';
 import { IMulticallService } from '@services/multicall';
 import { IPermit2Service } from '@services/permit2';
+import { IPriceService } from '@services/prices';
 import { IQuoteService } from '@services/quotes';
 
 export type BuildDCAParams = { customAPIUrl?: string };
@@ -10,10 +11,18 @@ type Dependencies = {
   permit2Service: IPermit2Service;
   quoteService: IQuoteService;
   fetchService: IFetchService;
+  priceService: IPriceService;
 };
 export function buildDCAService(
   params: BuildDCAParams | undefined,
-  { multicallService, permit2Service, quoteService, fetchService }: Dependencies
+  { multicallService, permit2Service, quoteService, fetchService, priceService }: Dependencies
 ) {
-  return new DCAService(params?.customAPIUrl ?? 'https://api.balmy.xyz', multicallService, permit2Service, quoteService, fetchService);
+  return new DCAService(
+    params?.customAPIUrl ?? 'https://api.balmy.xyz',
+    multicallService,
+    permit2Service,
+    quoteService,
+    fetchService,
+    priceService
+  );
 }

--- a/src/sdk/sdk-builder.ts
+++ b/src/sdk/sdk-builder.ts
@@ -26,7 +26,7 @@ export function buildSDK<Params extends BuildParams = {}>(
   const priceService = buildPriceService(params?.price, fetchService);
   const quoteService = buildQuoteService(params?.quotes, providerService, fetchService, gasService as any, metadataService as any, priceService);
   const permit2Service = buildPermit2Service(multicallService, quoteService, providerService, gasService as any);
-  const dcaService = buildDCAService(params?.dca, { multicallService, permit2Service, quoteService, fetchService });
+  const dcaService = buildDCAService(params?.dca, { multicallService, permit2Service, quoteService, fetchService, priceService });
 
   return {
     providerService,

--- a/src/services/dca/types.ts
+++ b/src/services/dca/types.ts
@@ -118,6 +118,8 @@ export type SwappedAction = {
   yield?: {
     rate: bigint;
   };
+  tokenA: { address: TokenAddress; price?: number };
+  tokenB: { address: TokenAddress; price?: number };
 };
 export type DCATransaction = {
   hash: string;


### PR DESCRIPTION
We are now using the price service to fill historic prices where necessary. The API could get rate-limited, so we do this at the SDK layer to fill any empty values