### PR TITLE
feat: adds sovryn as a source

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "package.json": "sort-package-json"
   },
   "dependencies": {
+    "@sovryn-zero/lib-base": "0.2.2",
+    "@sovryn/sdk": "0.0.6",
     "alchemy-sdk": "2.9.2",
     "cross-fetch": "3.1.5",
     "crypto-js": "4.1.1",
@@ -71,6 +73,7 @@
     "husky": "8.0.3",
     "jest": "29.7.0",
     "lint-staged": "13.2.2",
+    "patch-package": "8.0.0",
     "prettier": "2.8.8",
     "sort-package-json": "2.6.0",
     "ts-jest": "29.1.1",

--- a/patches/hardhat+2.13.0.dev.patch
+++ b/patches/hardhat+2.13.0.dev.patch
@@ -1,0 +1,90 @@
+diff --git a/node_modules/hardhat/internal/hardhat-network/jsonrpc/client.js b/node_modules/hardhat/internal/hardhat-network/jsonrpc/client.js
+index 8f78e83..71474ad 100644
+--- a/node_modules/hardhat/internal/hardhat-network/jsonrpc/client.js
++++ b/node_modules/hardhat/internal/hardhat-network/jsonrpc/client.js
+@@ -141,6 +145,60 @@ class JsonRpcClient {
+             reward: (0, io_ts_1.optional)(t.array(t.array(base_types_1.rpcQuantity))),
+         }), (res) => res.oldestBlock + BigInt(res.baseFeePerGas.length));
+     }
++    _patchRawResult(method, rawResult) {
++        /**
++         * Patch the raw results returned by _send or _sendBatch to fix RSK/Hardhat compatibility issues.
++         */
++        if (
++            method.startsWith('eth_getBlock') &&
++            rawResult &&
++            rawResult.transactions && rawResult.transactions.length
++        ) {
++            /*
++                * Calling a forked node (hardhat node --fork MY_RSK_NODE_RPC_URL) fails with:
++                * eth_call
++                * Invalid JSON-RPC response's result.
++                * Errors: Invalid value null supplied to : RpcBlockWithTransactions | null/transactions:
++                * RpcTransaction Array/0: RpcTransaction/v: QUANTITY, Invalid value null supplied to :
++                * RpcBlockWithTransactions | null/transactions: RpcTransaction Array/0: RpcTransaction/r:
++                * QUANTITY, Invalid value null supplied to : RpcBlockWithTransactions | null/transactions:
++                * RpcTransaction Array/0: RpcTransaction/s: QUANTITY
++                *
++                * This patch is based on:
++                * https://gist.github.com/0x0scion/0422f9135bc37642ba36d55b59e8b424
++                *
++                * More reading:
++                * https://github.com/NomicFoundation/hardhat/issues/2395
++                * https://github.com/NomicFoundation/hardhat/pull/2313/files
++                * https://github.com/NomicFoundation/hardhat/issues/2106
++                */
++            rawResult.transactions.forEach((t) => {
++                // Accesslist is sometimes missing, for other networks and maybe for RSK too
++                if (!t.accessList) t.accessList = [];
++                // Some RSK txs have null vrs
++                //       from: '0x0000000000000000000000000000000000000000',
++                //       to: '0x0000000000000000000000000000000001000008',
++                //       gas: '0x0',
++                //       gasPrice: '0x0',
++                //       value: '0x0',
++                //       input: '0x',
++                //       v: null,
++                //       r: null,
++                //       s: null
++                if (!t.v) t.v = '0x0';
++                if (!t.r) t.r = '0x0';
++                if (!t.s) t.s = '0x0';
++            });
++        } else if (method === 'eth_getStorageAt') {
++            /*
++                * This fixes the error in eth_getStorageAt that says 0x0 is an invalid value for DATA
++                */
++            if (rawResult === '0x0') {
++                rawResult = '0x0000000000000000000000000000000000000000000000000000000000000000';
++            }
++        }
++        return rawResult;
++    }
+     async getLatestBlockNumber() {
+         return this._perform("eth_blockNumber", [], base_types_1.rpcQuantity, (blockNumber) => blockNumber);
+     }
+@@ -157,7 +215,8 @@ class JsonRpcClient {
+                 return diskCachedResult;
+             }
+         }
+-        const rawResult = await this._send(method, params);
++        let rawResult = await this._send(method, params);
++        rawResult = this._patchRawResult(method, rawResult);
+         const decodedResult = (0, decodeJsonRpcResponse_1.decodeJsonRpcResponse)(rawResult, tType);
+         const blockNumber = getMaxAffectedBlockNumber(decodedResult);
+         if (this._canBeCached(blockNumber)) {
+@@ -186,7 +245,13 @@ class JsonRpcClient {
+             }
+         }
+         const rawResults = await this._sendBatch(batch);
+-        const decodedResults = rawResults.map((result, i) => (0, decodeJsonRpcResponse_1.decodeJsonRpcResponse)(result, batch[i].tType));
++        const decodedResults = rawResults.map((result, i) => {
++            result = this._patchRawResult(batch[i].method, result);
++            return (0, decodeJsonRpcResponse_1.decodeJsonRpcResponse)(
++                result,
++                batch[i].tType
++            );
++        });
+         const blockNumber = getMaxAffectedBlockNumber(decodedResults);
+         if (this._canBeCached(blockNumber)) {
+             this._storeInCache(cacheKey, decodedResults);

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -333,10 +333,10 @@ export const Chains = {
     chainId: 30,
     name: 'Rootstock',
     ids: ['rsk'],
-    nativeCurrency: { symbol: 'RBTC', name: 'Rootstock RSK' },
+    nativeCurrency: { symbol: 'RBTC', name: 'Smart Bitcoin' },
     wToken: '0x542fda317318ebf1d3deaf76e0b632741a7e677d',
-    publicRPCs: ['https://mycrypto.rsk.co', 'https://public-node.rsk.co'],
-    explorer: 'https://explorer.rsk.co/',
+    publicRPCs: ['https://public-node.rsk.co', 'https://mycrypto.rsk.co'],
+    explorer: 'https://rootstock.blockscout.com/',
   },
   POLYGON_ZKEVM: {
     chainId: 1101,

--- a/src/services/permit2/utils/config.ts
+++ b/src/services/permit2/utils/config.ts
@@ -22,4 +22,5 @@ export const PERMIT2_SUPPORTED_CHAINS = [
   Chains.POLYGON_ZKEVM,
   Chains.HECO,
   Chains.OKC,
+  Chains.ROOTSTOCK,
 ].map(({ chainId }) => chainId);

--- a/src/services/quotes/quote-sources/sovryn-source.ts
+++ b/src/services/quotes/quote-sources/sovryn-source.ts
@@ -39,19 +39,27 @@ export class SovrynQuoteSource extends AlwaysValidConfigAndContextSource<SovrynS
     // Create smart router
     // FIX: Enable routes ZeroRedemption, MoC and Mynt once they enable it's use without permit.
     const smartRouter = new SmartRouter(provider, Object.values([smartRoutes.ammSwapRoute]));
+    // Map buy and sell token since on Rootstock native token = address(0)
+    const mappedSellToken = mapNativeToken(sellToken);
+    const mappedBuyToken = mapNativeToken(buyToken);
     // Find best quote
     try {
-      const result = await smartRouter.getBestQuote(mapNativeToken(sellToken), mapNativeToken(buyToken), order.sellAmount);
+      const result = await smartRouter.getBestQuote(mappedSellToken, mappedBuyToken, order.sellAmount);
       // Get swap tx data
-      const swapTxData = await result.route.swap(mapNativeToken(sellToken), mapNativeToken(buyToken), order.sellAmount, takeFrom, {
+      const swapTxData = await result.route.swap(mappedSellToken, mappedBuyToken, order.sellAmount, takeFrom, {
         slippage: slippagePercentage * 100,
       });
+
+      if (!swapTxData || !swapTxData.to) {
+        throw new Error('Failed to calculate a quote');
+      }
+
       // Build quote
       const quote = {
         sellAmount: order.sellAmount,
         buyAmount: BigInt(result.quote.toString()),
         // FIX: Once the SDK starts exposing the allowance target, use that
-        allowanceTarget: calculateAllowanceTarget(sellToken, swapTxData?.to || Addresses.ZERO_ADDRESS),
+        allowanceTarget: calculateAllowanceTarget(sellToken, swapTxData.to),
         tx: {
           to: swapTxData.to!,
           calldata: swapTxData.data!.toString(),

--- a/src/services/quotes/quote-sources/sovryn-source.ts
+++ b/src/services/quotes/quote-sources/sovryn-source.ts
@@ -1,0 +1,74 @@
+import { Chains } from '@chains';
+import { Chain, Address } from '@types';
+import { Addresses } from '@shared/constants';
+import { IQuoteSource, QuoteParams, QuoteSourceMetadata, QuoteSourceSupport, SourceQuoteRequest, SourceQuoteResponse } from './types';
+import { addQuoteSlippage, failed } from './utils';
+import { isSameAddress } from '@shared/utils';
+import { DEFAULT_SWAP_ROUTES, SmartRouter, smartRoutes } from '@sovryn/sdk';
+import { AlwaysValidConfigAndContextSource } from './base/always-valid-source';
+
+export const SOVRYN_METADATA: QuoteSourceMetadata<SovrynSupport> = {
+  name: 'Sovryn',
+  supports: {
+    chains: [Chains.ROOTSTOCK.chainId],
+    swapAndTransfer: false,
+    buyOrders: false,
+  },
+  logoURI: 'ipfs://QmUpdb1zxtB2kUSjR1Qs1QMFPsSeZNkL21fMzGUfdjkXQA',
+};
+
+type SovrynSupport = { buyOrders: false; swapAndTransfer: false };
+export class SovrynQuoteSource extends AlwaysValidConfigAndContextSource<SovrynSupport> {
+  getMetadata() {
+    return SOVRYN_METADATA;
+  }
+
+  async quote({
+    components: { providerService },
+    request: {
+      chain,
+      sellToken,
+      buyToken,
+      order,
+      accounts: { takeFrom },
+      config: { slippagePercentage },
+    },
+  }: QuoteParams<SovrynSupport>): Promise<SourceQuoteResponse> {
+    // Get Rootstock provider
+    const provider = providerService.getEthersProvider({ chainId: Chains.ROOTSTOCK.chainId });
+    // Create smart router
+    // FIX: Enable routes ZeroRedemption, MoC and Mynt once they enable it's use without permit.
+    const smartRouter = new SmartRouter(provider, Object.values([smartRoutes.ammSwapRoute]));
+    // Find best quote
+    try {
+      const result = await smartRouter.getBestQuote(mapNativeToken(sellToken), mapNativeToken(buyToken), order.sellAmount);
+      // Get swap tx data
+      const swapTxData = await result.route.swap(mapNativeToken(sellToken), mapNativeToken(buyToken), order.sellAmount, takeFrom, {
+        slippage: slippagePercentage * 100,
+      });
+      // Build quote
+      const quote = {
+        sellAmount: order.sellAmount,
+        buyAmount: BigInt(result.quote.toString()),
+        // FIX: Once the SDK starts exposing the allowance target, use that
+        allowanceTarget: calculateAllowanceTarget(sellToken, swapTxData?.to || Addresses.ZERO_ADDRESS),
+        tx: {
+          to: swapTxData.to!,
+          calldata: swapTxData.data!.toString(),
+          value: isSameAddress(sellToken, Addresses.NATIVE_TOKEN) ? order.sellAmount : 0n,
+        },
+      };
+      return addQuoteSlippage(quote, order.type, slippagePercentage);
+    } catch (error: any) {
+      failed(SOVRYN_METADATA, chain, sellToken, buyToken, error.message);
+    }
+  }
+}
+
+function mapNativeToken(address: Address) {
+  return isSameAddress(address, Addresses.NATIVE_TOKEN) ? Addresses.ZERO_ADDRESS : address;
+}
+
+function calculateAllowanceTarget(sellToken: Address, allowanceTarget: Address) {
+  return isSameAddress(sellToken, Addresses.NATIVE_TOKEN) ? Addresses.ZERO_ADDRESS : allowanceTarget;
+}

--- a/src/services/quotes/source-registry.ts
+++ b/src/services/quotes/source-registry.ts
@@ -18,6 +18,7 @@ import { PortalsFiQuoteSource } from './quote-sources/portals-fi-quote-source';
 import { OKXDexQuoteSource } from './quote-sources/okx-dex-quote-source';
 import { BebopQuoteSource } from './quote-sources/bebop-quote-source';
 import { XYFinanceQuoteSource } from './quote-sources/xy-finance-quote-source';
+import { SovrynQuoteSource } from './quote-sources/sovryn-source';
 
 export const QUOTE_SOURCES = {
   bebop: new BebopQuoteSource(),
@@ -37,6 +38,7 @@ export const QUOTE_SOURCES = {
   wido: new WidoQuoteSource(),
   'portals-fi': new PortalsFiQuoteSource(),
   'okx-dex': new OKXDexQuoteSource(),
+  sovryn: new SovrynQuoteSource(),
 } satisfies Record<SourceId, IQuoteSource<QuoteSourceSupport, any>>;
 
 export const SOURCES_METADATA = Object.fromEntries(

--- a/test/integration/services/quotes/quote-tests-config.ts
+++ b/test/integration/services/quotes/quote-tests-config.ts
@@ -48,6 +48,7 @@ export enum Test {
 export const EXCEPTIONS: Partial<Record<string, Test[]>> = {
   uniswap: [Test.WRAP_NATIVE_TOKEN, Test.UNWRAP_WTOKEN],
   kyberswap: [Test.WRAP_NATIVE_TOKEN, Test.UNWRAP_WTOKEN],
+  sovryn: [Test.WRAP_NATIVE_TOKEN, Test.UNWRAP_WTOKEN],
   'mean-finance': [
     Test.SELL_STABLE_TO_NATIVE,
     Test.SELL_NATIVE_TO_RANDOM_ERC20,

--- a/test/integration/services/quotes/sources/quote-sources.spec.ts
+++ b/test/integration/services/quotes/sources/quote-sources.spec.ts
@@ -40,8 +40,8 @@ import { PrioritizedGasPriceSourceCombinator } from '@services/gas/gas-price-sou
 
 // This is meant to be used for local testing. On the CI, we will do something different
 const RUN_FOR: { source: keyof typeof SOURCES_METADATA; chains: Chain[] | 'all' } = {
-  source: 'xy-finance',
-  chains: [Chains.ETHEREUM],
+  source: 'sovryn',
+  chains: [Chains.ROOTSTOCK],
 };
 const ROUNDING_ISSUES: SourceId[] = ['rango', 'wido'];
 const AVOID_DURING_CI: SourceId[] = [
@@ -77,6 +77,7 @@ describe.skip('Quote Sources [External Quotes]', () => {
           to: userSigner,
           tokens: [
             { amount: parseUnits('10000', tokens.STABLE_ERC20.decimals), token: tokens.STABLE_ERC20 },
+            { amount: parseUnits('10000', tokens.RANDOM_ERC20.decimals), token: tokens.RANDOM_ERC20 },
             { amount: ONE_NATIVE_TOKEN * 3n, token: tokens.nativeToken },
             { amount: ONE_NATIVE_TOKEN, token: tokens.wToken },
           ],
@@ -301,7 +302,7 @@ describe.skip('Quote Sources [External Quotes]', () => {
         }
       }
 
-      const TRESHOLD_PERCENTAGE = 3; // 3%
+      const TRESHOLD_PERCENTAGE = 5; // 5%
       function validateQuote(from: TestToken, to: TestToken, fromAmount: bigint, toAmount: bigint) {
         const fromPriceBN = parseEther(`${from.price!}`);
         const toPriceBN = parseEther(`${to.price!}`);

--- a/test/integration/utils/erc20.ts
+++ b/test/integration/utils/erc20.ts
@@ -163,18 +163,18 @@ export const TOKENS: Record<ChainId, Record<string, TokenData>> = {
   },
   [Chains.ROOTSTOCK.chainId]: {
     STABLE_ERC20: {
-      // XUSD
-      address: '0xb5999795be0ebb5bab23144aa5fd6a02d080299f',
-      whale: '0x100aE71cBE5D2F678F9ae938909a8d8Dc004AA41',
+      // DLLR
+      address: '0xc1411567d2670e24d9c4daaa7cda95686e1250aa',
+      whale: '0x1440d19436beeaf8517896bffb957a88ec95a00f',
     },
     RANDOM_ERC20: {
       // SOV
       address: '0xefc78fc7d48b64958315949279ba181c2114abbd',
-      whale: '0x7f02eC1dF0238fEB228E1062BD2c5279A712d6aF',
+      whale: '0x5684a06cab22db16d901fee2a5c081b4c91ea40e',
     },
     wToken: {
       address: '0x542fda317318ebf1d3deaf76e0b632741a7e677d',
-      whale: '0xA9c3D9681215eF7623dc28eA6b75bF87fDf285D9',
+      whale: '0x5a0d867e0d70fcc6ade25c3f1b89d618b5b4eaa7',
     },
   },
   [Chains.AURORA.chainId]: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,6 +608,15 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
 
+"@ethersproject/bignumber@5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.0.15.tgz#b089b3f1e0381338d764ac1c10512f0c93b184ed"
+  integrity sha512-MTADqnyacvdRwtKh7o9ujwNDSM1SDJjYDMYAzjIgjoi9rh6TY4suMbhCa3i2vh3SUXiXSICyTI8ui+NPdrZ9Lw==
+  dependencies:
+    "@ethersproject/bytes" "^5.0.9"
+    "@ethersproject/logger" "^5.0.8"
+    bn.js "^4.4.0"
+
 "@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
@@ -617,7 +626,7 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
-"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.7.0":
+"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.0.9", "@ethersproject/bytes@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
   integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
@@ -707,7 +716,7 @@
     "@ethersproject/bytes" "^5.7.0"
     js-sha3 "0.8.0"
 
-"@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.7.0":
+"@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.0.8", "@ethersproject/logger@^5.7.0":
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
   integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
@@ -733,6 +742,32 @@
   integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/providers@5.7.1":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.1.tgz#b0799b616d5579cd1067a8ebf1fc1ec74c1e122c"
+  integrity sha512-vZveG/DLyo+wk4Ga1yx6jSEHrLPgmTt+dFv0dv8URpVCRf0jVhalps1jq/emN/oXnMRsC7cQgAF32DcXLL7BPQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
 
 "@ethersproject/providers@5.7.2", "@ethersproject/providers@^5.7.0":
   version "5.7.2"
@@ -1578,6 +1613,51 @@
   dependencies:
     "@sinonjs/commons" "^2.0.0"
 
+"@sovryn-zero/contracts@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@sovryn-zero/contracts/-/contracts-0.2.1.tgz#776df1dd8b61b3a7a83eb5312e09e9d80fa15704"
+  integrity sha512-wCVxPSXpt0ZKpqp9ARj8gc8OSpZU2ZMQYU6df7kSMEg3vwwVX1YUMQopQI3oVdUXmIukVnPtVy7DNaiwqLM88g==
+
+"@sovryn-zero/lib-base@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@sovryn-zero/lib-base/-/lib-base-0.2.2.tgz#e319618c345d7379806edff8c09d9e8fb66e0698"
+  integrity sha512-tiMyA+e2HGT89vh/Txgh8fm6gGhEK5+7KCfithn7znoR1/Bxx6iW8EDgMAMMJEb4iP7hWgswKaVV+XNU1Yy9Kg==
+  dependencies:
+    "@ethersproject/bignumber" "5.0.15"
+
+"@sovryn-zero/lib-ethers@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@sovryn-zero/lib-ethers/-/lib-ethers-0.2.5.tgz#a689b6b86686f7e54a6bbfac965a40f49a2fa4ea"
+  integrity sha512-EflaS8gsnlnslo1ZgxFm4c6xBAGPW1dJJ/8ItSgKhYBTYy50zulGRZwln3c4QVt4Sq6dkasix5NsqGXkTQutOA==
+
+"@sovryn/contracts@*":
+  version "1.0.17"
+  resolved "https://registry.yarnpkg.com/@sovryn/contracts/-/contracts-1.0.17.tgz#fb406e1f9f4eb01a775c76f91c3be785793bd399"
+  integrity sha512-RjjrTYbJKX9i3FwMZs3P8+OSH4aTnuE9zf32y3g7hMIH7bhQj4x9BBiDQ4EBFXoS0jiG1vKDsSikEtDLr1UlgA==
+  dependencies:
+    "@sovryn-zero/contracts" "0.2.1"
+    "@sovryn/ethers-provider" "*"
+    ethers "5.7.1"
+    lodash.get "4.4.2"
+    lodash.set "4.3.2"
+
+"@sovryn/ethers-provider@*":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@sovryn/ethers-provider/-/ethers-provider-1.0.2.tgz#0cb00e678c94e4c221c8aa43842b6cbf04e1b9bc"
+  integrity sha512-bxDC4n31IYkopmj8iVApA5tDNGPO5KXYZYRWgky12MPU2GEAOsWElqD9zTQp0bOjxZN4XYIJ7rX0awJDwaZRYw==
+  dependencies:
+    rxjs "7.5.6"
+
+"@sovryn/sdk@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@sovryn/sdk/-/sdk-0.0.6.tgz#19559c1dd6f47ba5f1b97565d8e499a28d6783e4"
+  integrity sha512-weBhgKJKgG8wTO8EB2par8RH/XxdqGzY0rjfP+GzL/doegr4p0uHp/4S2nfkWupEuA9Y0N8ywpZTo0saX53ZTg==
+  dependencies:
+    "@sovryn-zero/lib-ethers" "0.2.5"
+    "@sovryn/contracts" "*"
+    "@sovryn/ethers-provider" "*"
+    rxjs "7.5.6"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
@@ -1786,6 +1866,11 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@wagmi/chains/-/chains-1.2.0.tgz#d59eaa70ec51a5fdcd113975926992acfb17ab12"
   integrity sha512-dmDRipsE54JfyudOBkuhEexqQWcrZqxn/qiujG8SBzMh/az/AH5xlJSA+j1CPWTx9+QofSMF3B7A4gb6XRmSaQ==
+
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 JSONStream@^1.3.5:
   version "1.3.5"
@@ -2000,6 +2085,11 @@ async@^2.4.0:
   dependencies:
     lodash "^4.17.14"
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 axios@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
@@ -2111,7 +2201,7 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.2.1.tgz#5057e4206eadb4a97f7c0b6e197a505042fc3814"
   integrity sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==
 
-bn.js@^4.11.0, bn.js@^4.11.8, bn.js@^4.11.9:
+bn.js@^4.11.0, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^4.4.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -2321,7 +2411,7 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2363,6 +2453,11 @@ ci-info@^3.2.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.8.0.tgz#81408265a5380c929f0bc665d62256628ce9ef91"
   integrity sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==
+
+ci-info@^3.7.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
@@ -2909,6 +3004,42 @@ ethereumjs-util@^7.1.4:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
+ethers@5.7.1:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.1.tgz#48c83a44900b5f006eb2f65d3ba6277047fd4f33"
+  integrity sha512-5krze4dRLITX7FpU8J4WscXqADiKmyeNlylmmDLbS95DaZpBhDe2YSwRQwKXWNyXcox7a3gBgm/MkGXV1O1S/Q==
+  dependencies:
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/address" "5.7.0"
+    "@ethersproject/base64" "5.7.0"
+    "@ethersproject/basex" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/constants" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/hash" "5.7.0"
+    "@ethersproject/hdnode" "5.7.0"
+    "@ethersproject/json-wallets" "5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/logger" "5.7.0"
+    "@ethersproject/networks" "5.7.1"
+    "@ethersproject/pbkdf2" "5.7.0"
+    "@ethersproject/properties" "5.7.0"
+    "@ethersproject/providers" "5.7.1"
+    "@ethersproject/random" "5.7.0"
+    "@ethersproject/rlp" "5.7.0"
+    "@ethersproject/sha2" "5.7.0"
+    "@ethersproject/signing-key" "5.7.0"
+    "@ethersproject/solidity" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/units" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@ethersproject/web" "5.7.1"
+    "@ethersproject/wordlists" "5.7.0"
+
 ethers@5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
@@ -3084,6 +3215,13 @@ find-up@^4.0.0, find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
@@ -3132,6 +3270,16 @@ fs-extra@^7.0.1:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3275,6 +3423,11 @@ globby@^13.1.2:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^4.0.0"
+
+graceful-fs@^4.1.11:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -3543,6 +3696,11 @@ is-core-module@^2.5.0, is-core-module@^2.9.0:
   dependencies:
     has "^1.0.3"
 
+is-docker@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -3626,6 +3784,13 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-wsl@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -4100,6 +4265,13 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
+json-stable-stringify@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz#e06f23128e0bbe342dc996ed5a19e28b57b580e0"
+  integrity sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==
+  dependencies:
+    jsonify "^0.0.1"
+
 json5@^2.2.0, json5@^2.2.2, json5@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
@@ -4128,6 +4300,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -4146,6 +4323,13 @@ kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 klaw@^1.0.0:
   version "1.3.1"
@@ -4255,6 +4439,11 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
 
+lodash.get@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
 lodash.isfunction@^3.0.9:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
@@ -4284,6 +4473,11 @@ lodash.mergewith@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
   integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
+
+lodash.set@4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
 
 lodash.snakecase@^4.1.1:
   version "4.1.1"
@@ -4443,7 +4637,7 @@ merge2@^1.2.3, merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.4, micromatch@^4.0.5:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
   integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
@@ -4680,6 +4874,14 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
+
 ordinal@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ordinal/-/ordinal-1.0.3.tgz#1a3c7726a61728112f50944ad7c35c06ae3a0d4d"
@@ -4765,6 +4967,27 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+patch-package@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
+  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -5038,7 +5261,7 @@ rfdc@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rimraf@^2.2.8:
+rimraf@^2.2.8, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -5078,6 +5301,13 @@ rustbn.js@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
+
+rxjs@7.5.6:
+  version "7.5.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.6.tgz#0446577557862afd6903517ce7cae79ecb9662bc"
+  integrity sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==
+  dependencies:
+    tslib "^2.1.0"
 
 rxjs@^7.8.0:
   version "7.8.0"
@@ -5182,6 +5412,11 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -5478,7 +5713,7 @@ through2@^4.0.0:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tmp@0.0.33:
+tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==


### PR DESCRIPTION
So, there are a couple of things to notice in this PR:

- We will be using Sovryn's SDK that asks for a Ethers provider (connected to Rootstock) because they get information from on-chain (kinda like uniswap v2 routing).
- I've added `patch-package` and a file under `patches/` folder. This is due to the fact that rootstock nodes do not return the same data than standards ethereum nodes, so, to execute any tests on a Rootstock fork, `npx patch-package` must be executed. 
- We are ONLY enabling the AMM route on Sovryn, since the other once make it a requirement to submit a permit signature (we can't).
- I've tested this locally and it worked, I got another branch in the works to improve some of the testing on the integration `quote-source`